### PR TITLE
Add x86 move instructions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,7 +456,6 @@ pub mod actions {
         SubOverflowU(Bits),
         SubFp(Bits),
         Move(Bits),
-        PackedMove(Bits),
         IsZero,
         LtZero,
         Clear,
@@ -1707,7 +1706,7 @@ pub mod x64 {
                 ],
             )
             .move_packed_variants(
-                G::PackedMove,
+                G::Move,
                 [
                     (
                         32,


### PR DESCRIPTION
This pull request adds support for three classes of x86 move instructions:
1. Standard move instructions in 8, 16, 32, and 64-bit variants
2. Move transfer instructions which transfer between the integer and fp register file
3. Packed word and quardword move instruction.